### PR TITLE
Use chromosome key rather than id as index to chromSize

### DIFF
--- a/src/BigWigHeaderReader.ts
+++ b/src/BigWigHeaderReader.ts
@@ -219,7 +219,7 @@ function buildChromTree(chromTree: ChromTree, binaryParser: BinaryParser, offset
 
             chromTree.chromToId[key] = chromId;
             chromTree.idToChrom[chromId] = key;
-            chromTree.chromSize[chromId] = chromSize;
+            chromTree.chromSize[key] = chromSize;
         }
     } else {
         for (let i = 0; i < count; i++) {


### PR DESCRIPTION
A small tweak to the last PR, I think it's better to use the chromosome key rather than id as the index to the chromosome size map – my mistake for PRing earlier